### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -103,7 +103,7 @@ prioritizing the client requests.
 Separate out the prioritizing client requests and make it common to all 
 providers.
 
-Is pipe-ling requests possible?
+Is pipe-lining requests possible?
 
 
 


### PR DESCRIPTION
Assuming it was 'pipe-lining' and not 'piping', here's a correction to 'pipe-ling', which may not be English.